### PR TITLE
fix: preserve null values in history trend chart for gap rendering

### DIFF
--- a/src/components/layout/HistoryPanel.tsx
+++ b/src/components/layout/HistoryPanel.tsx
@@ -62,14 +62,17 @@ export function HistoryPanel() {
         if (Array.isArray(result.value)) {
           for (const item of result.value) {
             if (item && typeof item === 'object' && 'timestamp' in item) {
-              // Skip points with null/undefined values - they're not meaningful history
-              const itemValue = (item as Record<string, unknown>).value
-              if (itemValue === null || itemValue === undefined) {
-                continue
-              }
+              // Null/undefined values must be preserved for trend charts.
+              // The HistoryTrendChart renders nulls as visual gaps in the SVG path
+              // using M (move-to) commands. Filtering them out here would hide
+              // periods where the server returned no data.
+              // const itemValue = (item as Record<string, unknown>).value
+              // if (itemValue === null || itemValue === undefined) {
+              //   continue
+              // }
               points.push({
                 timestamp: item.timestamp as string,
-                value: itemValue,
+                value: (item as Record<string, unknown>).value,
                 quality: item.quality as string | undefined
               })
             }


### PR DESCRIPTION
## Summary
- Reverts null value filtering in HistoryPanel data extraction that was incorrectly discarding null data points before they reached the trend chart

## Why null values matter for trending

In time-series trending, null values represent periods where the server had no data — sensor disconnections, communication failures, or intentional gaps. Silently removing these points creates a misleading visualization: the chart draws a continuous line between the last known value and the next, implying data continuity where none existed.

The `HistoryTrendChart` component already handles nulls correctly by rendering them as visual gaps in the SVG path (using `M` move-to commands instead of `L` line-to commands). Filtering nulls at the data extraction stage bypassed this gap rendering entirely.

## Test plan
- [ ] Connect to an i3X server with objects that return null/missing history values
- [ ] Verify the trend chart shows visible gaps where null values exist
- [ ] Verify continuous data still renders as an unbroken line