### PR TITLE
Tree view: chevron accuracy, filter, counts, icon system, leader lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ build/*.png
 scripts/nginx-web.conf
 scripts/i3x-explorer-web.service
 config.local.json
+demo/boiler.html
+.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,4 @@ scripts/nginx-web.conf
 scripts/i3x-explorer-web.service
 config.local.json
 demo/boiler.html
-.claude/settings.json
+.claude/

--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@ The official cross-platform desktop application for browsing and monitoring [I3X
 
 ## Features
 
-- Connect to any I3X-compliant server
-- Browse hierarchical data: Namespaces → Object Types → Objects
-- Tree auto-refresh: expanding a branch re-fetches from the server; 30s background poll keeps data current
-- View object details, metadata, and current values
-- Subscribe to objects for real-time updates via SSE
-- Search and filter the object tree
+- Connect to any I3X-compliant server (auto-detects v0, v1-beta, and v1 wire formats)
+- Three browse views in one tree:
+  - **Namespaces** → Object Types → Object Instances
+  - **Objects** (flat list of every instance the server exposes)
+  - **Hierarchy** (parent/child structure, with one root per upstream server when fronting a wrapper)
+- Inline filter bar pinned at the top of the tree; deep matches surface their ancestor namespaces, types, and hierarchy parents so they stay visible
+- Top-level folders auto-expand on search so matches are visible without manual clicks
+- Object counts at every level — folders, namespaces, types, and hierarchy nodes
+- Authoritative chevron state: branches that have no expandable children don't show a chevron, even when the underlying object claims to be compositional
+- View object details, metadata, schema extensions, and current values
+- Relationship graph for non-compositional relationships
+- Subscribe to objects for real-time updates via SSE (with polling fallback) and a trend chart for numeric values
+- Global object search modal (⌘K / Ctrl+K) that navigates and expands to any match by name or elementId
+- Tree auto-refresh: expanding a branch re-fetches from the server; 30s background poll keeps expanded branches current
 - Light and dark theme with toggle button (follows OS preference by default)
 
 ## Installation

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,13 +20,28 @@ ipcMain.handle('safe-storage-decrypt', (_event, encrypted: string) => {
   return safeStorage.decryptString(Buffer.from(encrypted, 'base64'))
 })
 
-// IPC handler to open DevTools
+// IPC handler to toggle DevTools (open if closed, close if open)
 ipcMain.handle('open-devtools', (event) => {
   const webContents = event.sender
-  webContents.openDevTools({ mode: 'detach' })
+  if (webContents.isDevToolsOpened()) {
+    webContents.closeDevTools()
+  } else {
+    webContents.openDevTools({ mode: 'detach' })
+  }
 })
 
 let mainWindow: BrowserWindow | null = null
+
+// Coordinates renderer cleanup (closing SSE streams, deleting server-side
+// subscriptions) before the app exits. Without this the process is killed
+// while subscriptions are still registered server-side.
+let cleanupRan = false
+let cleanupAck: (() => void) | null = null
+
+ipcMain.on('app-cleanup-done', () => {
+  cleanupAck?.()
+  cleanupAck = null
+})
 
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL']
 
@@ -89,6 +104,26 @@ app.whenReady().then(() => {
   }
 
   createWindow()
+})
+
+app.on('before-quit', async (event) => {
+  if (cleanupRan) return
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+    cleanupRan = true
+    return
+  }
+
+  event.preventDefault()
+
+  mainWindow.webContents.send('app-before-quit')
+
+  await new Promise<void>((resolve) => {
+    cleanupAck = resolve
+    setTimeout(resolve, 3000)
+  })
+
+  cleanupRan = true
+  app.quit()
 })
 
 app.on('window-all-closed', () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,5 +15,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Open DevTools in detached window
   openDevTools: () => {
     return ipcRenderer.invoke('open-devtools')
-  }
+  },
+  onAppBeforeQuit: (callback) => {
+    const listener = () => callback()
+    ipcRenderer.on('app-before-quit', listener)
+    return () => ipcRenderer.removeListener('app-before-quit', listener)
+  },
+  notifyCleanupDone: () => ipcRenderer.send('app-cleanup-done')
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
+import { useEffect } from 'react'
 import { useConnectionStore } from './stores/connection'
+import { useSubscriptionsStore } from './stores/subscriptions'
+import { getClient } from './api/client'
 import { Toolbar } from './components/layout/Toolbar'
 import { Sidebar } from './components/layout/Sidebar'
 import { MainPanel } from './components/layout/MainPanel'
@@ -9,6 +12,21 @@ import { UpdateChecker } from './components/updater/UpdateChecker'
 
 function App() {
   const { showConnectionDialog } = useConnectionStore()
+
+  useEffect(() => {
+    if (!window.electronAPI?.onAppBeforeQuit) return
+    return window.electronAPI.onAppBeforeQuit(async () => {
+      try {
+        const client = getClient()
+        if (client) {
+          const ids = Array.from(useSubscriptionsStore.getState().subscriptions.keys())
+          await Promise.allSettled(ids.map((id) => client.deleteSubscription(id)))
+        }
+      } finally {
+        window.electronAPI?.notifyCleanupDone()
+      }
+    })
+  }, [])
 
   return (
     <div className="h-full flex flex-col bg-i3x-bg">

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -311,6 +311,40 @@ export class I3XClient {
     })
   }
 
+  // Batch /objects/related — used to authoritatively determine which parents
+  // have qualifying compositional children (for tree chevrons), in one round
+  // trip instead of one call per parent. Returns Map<parentElementId, children[]>.
+  // v1 only.
+  async getRelatedObjectsBatch(
+    elementIds: string[],
+    relationshipType?: string
+  ): Promise<Map<string, ObjectInstance[]>> {
+    const out = new Map<string, ObjectInstance[]>()
+    if (elementIds.length === 0 || !this.isV1()) return out
+    const raw = await this.request<unknown>('POST', '/objects/related', {
+      elementIds,
+      relationshipType,
+      includeMetadata: false
+    })
+    const results = extractV1BulkResults<Array<Record<string, unknown>>>(raw)
+    for (const item of results) {
+      if (!item.success || !Array.isArray(item.result)) {
+        out.set(item.elementId, [])
+        continue
+      }
+      const objects: ObjectInstance[] = []
+      for (const envelope of item.result) {
+        const inner = (envelope.object ?? envelope) as Record<string, unknown>
+        const r = envelope.object
+          ? { ...inner, sourceRelationship: envelope.sourceRelationship }
+          : inner
+        objects.push(normalizeV1Object(r as Record<string, unknown>))
+      }
+      out.set(item.elementId, objects)
+    }
+    return out
+  }
+
   // Value Methods (RFC 4.2.1)
 
   async getValue(elementId: string, maxDepth = 1): Promise<LastKnownValue | null> {

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -51,7 +51,7 @@ export function Toolbar() {
     disconnect: disconnectStore
   } = useConnectionStore()
 
-  const { setNamespaces, setObjectTypes, setLoading, reset: resetExplorer, pollIntervalMs, setPollIntervalMs, triggerManualRefresh } = useExplorerStore()
+  const { setNamespaces, setObjectTypes, setAllObjects, setHierarchicalRoots, setLoading, reset: resetExplorer, pollIntervalMs, setPollIntervalMs, triggerManualRefresh } = useExplorerStore()
   const { clearAll: clearSubscriptions } = useSubscriptionsStore()
 
   useEffect(() => {
@@ -95,6 +95,13 @@ export function Toolbar() {
         setNamespaces(namespaces)
         setObjectTypes(objectTypes)
         setLoading(false)
+
+        // Fire-and-forget: prefetch flat object list + hierarchy roots so the
+        // tree's [count] indicators show before the user expands those folders.
+        // Doesn't block the connect flow; expansion later refetches with
+        // composition resolution, so chevron accuracy isn't affected.
+        client.getObjects().then(setAllObjects).catch(() => {})
+        client.getObjects(undefined, false, true).then(setHierarchicalRoots).catch(() => {})
       } else {
         setError('Failed to connect to server')
         destroyClient()

--- a/src/components/tree/TreeView.tsx
+++ b/src/components/tree/TreeView.tsx
@@ -38,7 +38,9 @@ async function resolveCompositionFlags(client: I3XClient, loaded: ObjectInstance
 const BACKGROUND_POLL_ENABLED = true
 
 // Icons
-const FolderIcon = () => <span className="text-i3x-warning">🗄️</span>
+const FolderIcon = () => (
+  <span style={{ filter: 'sepia(1) saturate(1.6) hue-rotate(-15deg) brightness(0.89)' }}>🗄️</span>
+)
 const NamespaceIcon = () => <span className="text-i3x-primary">🌐</span>
 const TypeIcon = () => <span className="text-i3x-success">📃</span>
 const CompositionObjectIcon = () => <span className="text-i3x-secondary">📦</span>
@@ -61,10 +63,13 @@ interface TreeNodeProps {
   data?: Namespace | ObjectType | ObjectInstance
   depth: number
   hasChildren?: boolean
+  // Optional minimalist count badge rendered to the right of the label —
+  // small, muted, no brackets. Only rendered when defined.
+  count?: number
   children?: React.ReactNode
 }
 
-function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeNodeProps) {
+function TreeNode({ id, label, type, data, depth, hasChildren, count, children }: TreeNodeProps) {
   const { expandedNodes, selectedItem, toggleNode, selectItem, setObjects, setAllObjects, setHierarchicalRoots, setChildObjects } = useExplorerStore()
 
   const isExpanded = expandedNodes.has(id)
@@ -194,7 +199,12 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
         )}
         {!hasChildren && <span className="w-4" />}
         <span className="flex-shrink-0">{getIcon()}</span>
-        <span className="truncate text-sm">{label}</span>
+        <span className="truncate text-sm">
+          {label}
+          {count !== undefined && (
+            <span className="ml-1.5 text-i3x-text-muted/60 tabular-nums">{count}</span>
+          )}
+        </span>
       </div>
       {isExpanded && children}
     </div>
@@ -288,22 +298,23 @@ function HierarchicalObjectNode({
   depth,
   filterText,
   allObjects,
+  visibleIds,
   ancestors = new Set<string>()
 }: {
   obj: ObjectInstance
   depth: number
   filterText: string
   allObjects: ObjectInstance[]
+  // When filterText is active, set of object IDs that should remain visible
+  // (matches + their ancestors). Computed once at the TreeView level.
+  visibleIds?: Set<string>
   ancestors?: Set<string>
 }) {
   // Find children by filtering allObjects where parentId matches this object
   const children = allObjects.filter(child => child.parentId === obj.elementId)
-  const filteredChildren = children.filter(
-    (child) =>
-      !filterText ||
-      child.displayName.toLowerCase().includes(filterText) ||
-      child.elementId.toLowerCase().includes(filterText)
-  )
+  const filteredChildren = filterText
+    ? children.filter(child => visibleIds?.has(child.elementId))
+    : children
 
   // Prevent infinite recursion - depth limit or cycle detection
   if (depth > MAX_TREE_DEPTH || ancestors.has(obj.elementId)) {
@@ -336,6 +347,7 @@ function HierarchicalObjectNode({
           depth={depth + 1}
           filterText={filterText}
           allObjects={allObjects}
+          visibleIds={visibleIds}
           ancestors={childAncestors}
         />
       ))}
@@ -344,7 +356,7 @@ function HierarchicalObjectNode({
 }
 
 export function TreeView() {
-  const { namespaces, objectTypes, objects, allObjects, hierarchicalRoots, searchQuery, pollIntervalMs, manualRefreshTick } = useExplorerStore()
+  const { namespaces, objectTypes, objects, allObjects, hierarchicalRoots, searchQuery, setSearchQuery, pollIntervalMs, manualRefreshTick } = useExplorerStore()
   const isConnected = useConnectionStore(state => state.isConnected)
 
   const refreshTree = useCallback(async () => {
@@ -434,52 +446,107 @@ export function TreeView() {
     refreshTree()
   }, [manualRefreshTick, isConnected, refreshTree])
 
-  // Filter based on search
-  const filterText = searchQuery.toLowerCase()
+  // Auto-expand the three root folders whenever a search query is active so
+  // matches are visible without the user having to click each folder open.
+  useEffect(() => {
+    if (!searchQuery.trim()) return
+    const { expandNode } = useExplorerStore.getState()
+    expandNode(NAMESPACES_FOLDER_ID)
+    expandNode(OBJECTS_FOLDER_ID)
+    expandNode(HIERARCHICAL_FOLDER_ID)
+  }, [searchQuery])
 
-  const filteredNamespaces = namespaces.filter(
-    (ns) =>
+  // Filter based on search. To make deep matches surface their ancestors,
+  // we precompute three sets:
+  //   matchingTypeIds: type IDs that have ≥1 matching object (so the type and
+  //     its parent namespace stay visible even if their own names don't match)
+  //   hierarchyVisibleIds: object IDs to keep in the Hierarchy view —
+  //     every match plus every ancestor up the parentId chain
+  //   matchedNamespaceUris: namespace URIs reached transitively via matching
+  //     types/objects (so a namespace whose name doesn't match still renders
+  //     when something inside it does)
+  const filterText = searchQuery.toLowerCase()
+  const objMatches = (obj: ObjectInstance) =>
+    obj.displayName.toLowerCase().includes(filterText) ||
+    obj.elementId.toLowerCase().includes(filterText)
+
+  const matchingTypeIds = new Set<string>()
+  const hierarchyVisibleIds = new Set<string>()
+  const matchedNamespaceUris = new Set<string>()
+  if (filterText) {
+    const objById = new Map(allObjects.map(o => [o.elementId, o]))
+    for (const obj of allObjects) {
+      if (!objMatches(obj)) continue
+      matchingTypeIds.add(obj.typeId)
+      // Walk parents up to the root, marking every ancestor visible
+      let cur: ObjectInstance | undefined = obj
+      while (cur && !hierarchyVisibleIds.has(cur.elementId)) {
+        hierarchyVisibleIds.add(cur.elementId)
+        cur = cur.parentId ? objById.get(cur.parentId) : undefined
+      }
+    }
+    // Any type that matches by name OR by descendant pulls its namespace in
+    for (const type of objectTypes) {
+      const typeMatches =
+        type.displayName.toLowerCase().includes(filterText) ||
+        type.elementId.toLowerCase().includes(filterText) ||
+        matchingTypeIds.has(type.elementId)
+      if (typeMatches) matchedNamespaceUris.add(type.namespaceUri)
+    }
+  }
+
+  const filteredNamespaces = namespaces.filter(ns => {
+    if (!filterText) return true
+    if (
       ns.displayName.toLowerCase().includes(filterText) ||
       ns.uri.toLowerCase().includes(filterText)
-  )
+    ) return true
+    return matchedNamespaceUris.has(ns.uri)
+  })
 
-  // Group object types by namespace
+  // Group object types by namespace; keep types whose name matches OR whose
+  // descendant objects match.
   const typesByNamespace = new Map<string, ObjectType[]>()
   objectTypes.forEach((type) => {
-    if (
+    const keep =
       !filterText ||
       type.displayName.toLowerCase().includes(filterText) ||
-      type.elementId.toLowerCase().includes(filterText)
-    ) {
+      type.elementId.toLowerCase().includes(filterText) ||
+      matchingTypeIds.has(type.elementId)
+    if (keep) {
       const types = typesByNamespace.get(type.namespaceUri) || []
       types.push(type)
       typesByNamespace.set(type.namespaceUri, types)
     }
   })
 
-  // Filter all objects for the Objects folder
-  const filteredAllObjects = allObjects.filter(
-    (obj) =>
-      !filterText ||
-      obj.displayName.toLowerCase().includes(filterText) ||
-      obj.elementId.toLowerCase().includes(filterText)
-  )
+  // Filter all objects for the Objects folder (flat list — only direct matches)
+  const filteredAllObjects = allObjects.filter(obj => !filterText || objMatches(obj))
 
   const filteredHierarchicalRoots = hierarchicalRoots.filter(
-    (obj) =>
-      !filterText ||
-      obj.displayName.toLowerCase().includes(filterText) ||
-      obj.elementId.toLowerCase().includes(filterText)
+    obj => !filterText || hierarchyVisibleIds.has(obj.elementId)
   )
 
   const hasNamespaces = namespaces.length > 0
 
   return (
     <div className="text-i3x-text">
+      {/* Filter input */}
+      <div className="sticky top-0 z-10 bg-i3x-surface pb-2 mb-1">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="Filter tree…"
+          className="w-full px-2 py-1 text-sm bg-i3x-bg border border-i3x-border rounded text-i3x-text placeholder:text-i3x-text-muted focus:outline-none focus:border-i3x-primary"
+        />
+      </div>
+
       {/* Namespaces folder */}
       <TreeNode
         id={NAMESPACES_FOLDER_ID}
         label="Namespaces"
+        count={namespaces.length > 0 ? namespaces.length : undefined}
         type="folder"
         depth={0}
         hasChildren={hasNamespaces}
@@ -537,6 +604,7 @@ export function TreeView() {
       <TreeNode
         id={OBJECTS_FOLDER_ID}
         label="Objects"
+        count={allObjects.length > 0 ? allObjects.length : undefined}
         type="folder"
         depth={0}
         hasChildren={true}
@@ -560,6 +628,7 @@ export function TreeView() {
       <TreeNode
         id={HIERARCHICAL_FOLDER_ID}
         label="Hierarchy"
+        count={hierarchicalRoots.length > 0 ? hierarchicalRoots.length : undefined}
         type="folder"
         depth={0}
         hasChildren={true}
@@ -571,6 +640,7 @@ export function TreeView() {
             depth={1}
             filterText={filterText}
             allObjects={allObjects}
+            visibleIds={hierarchyVisibleIds}
           />
         ))}
         {allObjects.length > 0 && filteredHierarchicalRoots.length === 0 && (

--- a/src/components/tree/TreeView.tsx
+++ b/src/components/tree/TreeView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useExplorerStore, type SelectedItem } from '../../stores/explorer'
 import { useConnectionStore } from '../../stores/connection'
 import { getClient, type I3XClient } from '../../api/client'
@@ -192,6 +192,10 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={handleClick}
       >
+        {/* Non-root nodes: count rendered to the left of the chevron */}
+        {type !== 'folder' && count !== undefined && (
+          <span className="text-sm text-i3x-text-muted/60 tabular-nums flex-shrink-0">{count}</span>
+        )}
         {hasChildren && (
           <span className="w-4 flex-shrink-0">
             {isExpanded ? <ChevronDown /> : <ChevronRight />}
@@ -201,7 +205,8 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
         <span className="flex-shrink-0">{getIcon()}</span>
         <span className="truncate text-sm">
           {label}
-          {count !== undefined && (
+          {/* Root folders: count rendered after the label */}
+          {type === 'folder' && count !== undefined && (
             <span className="ml-1.5 text-i3x-text-muted/60 tabular-nums">{count}</span>
           )}
         </span>
@@ -335,6 +340,7 @@ function HierarchicalObjectNode({
     <TreeNode
       id={`hier:${obj.elementId}`}
       label={getObjectLabel(obj)}
+      count={children.length > 0 ? children.length : undefined}
       type="object"
       data={obj}
       depth={depth}
@@ -529,6 +535,16 @@ export function TreeView() {
 
   const hasNamespaces = namespaces.length > 0
 
+  // Instance count per type, derived from already-loaded allObjects (no extra
+  // network). Memoized so the group-by only runs when allObjects changes, not
+  // on every keystroke in the filter input. Hierarchy node counts are derived
+  // locally from each node's `children` array, so no parent map needed here.
+  const objectCountByType = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const o of allObjects) m.set(o.typeId, (m.get(o.typeId) ?? 0) + 1)
+    return m
+  }, [allObjects])
+
   return (
     <div className="text-i3x-text">
       {/* Filter input */}
@@ -560,6 +576,7 @@ export function TreeView() {
               key={namespace.uri}
               id={`ns:${namespace.uri}`}
               label={namespace.displayName}
+              count={nsTypes.length > 0 ? nsTypes.length : undefined}
               type="namespace"
               data={namespace}
               depth={1}
@@ -573,12 +590,14 @@ export function TreeView() {
                     obj.displayName.toLowerCase().includes(filterText) ||
                     obj.elementId.toLowerCase().includes(filterText)
                 )
+                const instanceCount = objectCountByType.get(type.elementId)
 
                 return (
                   <TreeNode
                     key={type.elementId}
                     id={`type:${type.elementId}`}
                     label={type.displayName}
+                    count={instanceCount && instanceCount > 0 ? instanceCount : undefined}
                     type="objectType"
                     data={type}
                     depth={2}

--- a/src/components/tree/TreeView.tsx
+++ b/src/components/tree/TreeView.tsx
@@ -1,8 +1,39 @@
 import { useCallback, useEffect } from 'react'
 import { useExplorerStore, type SelectedItem } from '../../stores/explorer'
 import { useConnectionStore } from '../../stores/connection'
-import { getClient } from '../../api/client'
+import { getClient, type I3XClient } from '../../api/client'
 import type { Namespace, ObjectType, ObjectInstance } from '../../api/types'
+
+// After loading a layer of objects, decide chevron state for each compositional
+// parent by asking the server what /objects/related actually returns — i.e. the
+// same data the render filter sees at expansion time. Single batch round trip.
+// Awaiting this before committing layer state ensures chevrons render correctly
+// on first paint instead of flipping after a follow-up fetch.
+async function resolveCompositionFlags(client: I3XClient, loaded: ObjectInstance[]): Promise<void> {
+  if (loaded.length === 0) return
+  const { compositionCache, mergeCompositionFlags } = useExplorerStore.getState()
+  const toResolve: string[] = []
+  for (const obj of loaded) {
+    if (obj.isComposition && !compositionCache.has(obj.elementId)) {
+      toResolve.push(obj.elementId)
+    }
+  }
+  if (toResolve.length === 0) return
+  const additions = new Map<string, boolean>()
+  try {
+    const related = await client.getRelatedObjectsBatch(toResolve, 'HasComponent')
+    for (const parentId of toResolve) {
+      const children = related.get(parentId) ?? []
+      const hasQualifying = children.some(c =>
+        c.isComposition && c.elementId !== parentId && c.parentId === parentId
+      )
+      additions.set(parentId, hasQualifying)
+    }
+  } catch (err) {
+    console.error('Failed to resolve composition flags via /objects/related:', err)
+  }
+  if (additions.size > 0) mergeCompositionFlags(additions)
+}
 
 const BACKGROUND_POLL_ENABLED = true
 
@@ -11,6 +42,9 @@ const FolderIcon = () => <span className="text-i3x-warning">🗄️</span>
 const NamespaceIcon = () => <span className="text-i3x-primary">🌐</span>
 const TypeIcon = () => <span className="text-i3x-success">📃</span>
 const CompositionObjectIcon = () => <span className="text-i3x-secondary">📦</span>
+const EmptyCompositionObjectIcon = () => (
+  <span style={{ filter: 'grayscale(1)', opacity: 0.6 }}>📦</span>
+)
 const LeafObjectIcon = () => <span className="text-i3x-secondary">🗒️</span>
 const ChevronRight = () => <span className="text-i3x-text-muted">›</span>
 const ChevronDown = () => <span className="text-i3x-text-muted">⌄</span>
@@ -53,6 +87,7 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
           try {
             const objectType = data as ObjectType
             const objects = await client.getObjects(objectType.elementId)
+            await resolveCompositionFlags(client, objects)
             setObjects(objectType.elementId, objects)
           } catch (err) {
             console.error('Failed to load objects:', err)
@@ -66,6 +101,7 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
         if (client) {
           try {
             const objects = await client.getObjects()
+            await resolveCompositionFlags(client, objects)
             setAllObjects(objects)
           } catch (err) {
             console.error('Failed to load all objects:', err)
@@ -80,6 +116,7 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
         if (client) {
           try {
             const roots = await client.getObjects(undefined, false, true)
+            await resolveCompositionFlags(client, roots)
             setHierarchicalRoots(roots)
           } catch (err) {
             console.error('Failed to load root objects:', err)
@@ -93,6 +130,7 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
         if (client) {
           try {
             const objects = await client.getObjects()
+            await resolveCompositionFlags(client, objects)
             setAllObjects(objects)
           } catch (err) {
             console.error('Failed to refresh objects for hierarchy node:', err)
@@ -113,6 +151,7 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
                 child.elementId !== obj.elementId &&
                 child.parentId === obj.elementId
               )
+              await resolveCompositionFlags(client, compositionalChildren)
               setChildObjects(obj.elementId, compositionalChildren)
             } catch (err) {
               console.error('Failed to load child objects:', err)
@@ -129,8 +168,13 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
         return <NamespaceIcon />
       case 'objectType':
         return <TypeIcon />
-      case 'object':
-        return hasChildren ? <CompositionObjectIcon /> : <LeafObjectIcon />
+      case 'object': {
+        const obj = data as ObjectInstance | undefined
+        if (obj?.isComposition) {
+          return hasChildren ? <CompositionObjectIcon /> : <EmptyCompositionObjectIcon />
+        }
+        return <LeafObjectIcon />
+      }
       case 'folder':
         return <FolderIcon />
     }
@@ -160,6 +204,15 @@ function TreeNode({ id, label, type, data, depth, hasChildren, children }: TreeN
 // Max depth for tree rendering to prevent infinite loops
 const MAX_TREE_DEPTH = 20
 
+// Chevron predicate: consult the compositionCache, which holds the answer
+// resolved via batched /objects/related. If we haven't resolved this object
+// yet, fall back to its isComposition flag (chevron may show momentarily).
+function hasCompositionChildren(obj: ObjectInstance, cache: Map<string, boolean>): boolean {
+  if (!obj.isComposition) return false
+  const cached = cache.get(obj.elementId)
+  return cached ?? true
+}
+
 // Get display label for an object, handling special cases like root "/"
 function getObjectLabel(obj: ObjectInstance): string {
   if (obj.displayName && obj.displayName.trim()) {
@@ -183,8 +236,9 @@ function ObjectNode({
 }) {
   // Subscribe only to this object's children, not the entire map
   const children = useExplorerStore(
-    (state) => state.childObjects.get(obj.elementId) || []
+    (state) => state.childObjects.get(obj.elementId) ?? []
   )
+  const compositionCache = useExplorerStore((state) => state.compositionCache)
   const filteredChildren = children.filter(
     (child) =>
       !filterText ||
@@ -212,7 +266,7 @@ function ObjectNode({
       type="object"
       data={obj}
       depth={depth}
-      hasChildren={obj.isComposition}
+      hasChildren={hasCompositionChildren(obj, compositionCache)}
     >
       {filteredChildren.map((child) => (
         <ObjectNode
@@ -318,6 +372,7 @@ export function TreeView() {
         const typeElementId = nodeId.slice(5)
         try {
           const objects = await client.getObjects(typeElementId)
+          await resolveCompositionFlags(client, objects)
           setObjects(typeElementId, objects)
         } catch (err) {
           console.error('Background refresh: type failed', typeElementId, err)
@@ -328,6 +383,7 @@ export function TreeView() {
         allObjectsRefreshed = true
         try {
           const objects = await client.getObjects()
+          await resolveCompositionFlags(client, objects)
           setAllObjects(objects)
         } catch (err) {
           console.error('Background refresh: all objects failed', err)
@@ -337,6 +393,7 @@ export function TreeView() {
       if (nodeId === HIERARCHICAL_FOLDER_ID) {
         try {
           const roots = await client.getObjects(undefined, false, true)
+          await resolveCompositionFlags(client, roots)
           setHierarchicalRoots(roots)
         } catch (err) {
           console.error('Background refresh: root objects failed', err)
@@ -354,6 +411,7 @@ export function TreeView() {
               child.elementId !== elementId &&
               child.parentId === elementId
             )
+            await resolveCompositionFlags(client, compositionalChildren)
             setChildObjects(elementId, compositionalChildren)
           } catch (err) {
             console.error('Background refresh: children failed', elementId, err)
@@ -441,7 +499,7 @@ export function TreeView() {
               hasChildren={hasTypes}
             >
               {nsTypes.map((type) => {
-                const typeObjects = objects.get(type.elementId) || []
+                const typeObjects = objects.get(type.elementId) ?? []
                 const filteredObjects = typeObjects.filter(
                   (obj) =>
                     !filterText ||

--- a/src/components/tree/TreeView.tsx
+++ b/src/components/tree/TreeView.tsx
@@ -19,15 +19,15 @@ async function resolveCompositionFlags(client: I3XClient, loaded: ObjectInstance
     }
   }
   if (toResolve.length === 0) return
-  const additions = new Map<string, boolean>()
+  const additions = new Map<string, number>()
   try {
     const related = await client.getRelatedObjectsBatch(toResolve, 'HasComponent')
     for (const parentId of toResolve) {
       const children = related.get(parentId) ?? []
-      const hasQualifying = children.some(c =>
+      const qualifyingCount = children.filter(c =>
         c.isComposition && c.elementId !== parentId && c.parentId === parentId
-      )
-      additions.set(parentId, hasQualifying)
+      ).length
+      additions.set(parentId, qualifyingCount)
     }
   } catch (err) {
     console.error('Failed to resolve composition flags via /objects/related:', err)
@@ -41,13 +41,35 @@ const BACKGROUND_POLL_ENABLED = true
 const FolderIcon = () => (
   <span style={{ filter: 'sepia(1) saturate(1.6) hue-rotate(-15deg) brightness(0.89)' }}>🗄️</span>
 )
+// 📁 emoji renders grey on some macOS configurations; sepia/saturate filter
+// forces a manilla tint while keeping the emoji aesthetic of the rest of the
+// tree.
+const FolderTypeIcon = () => (
+  <span style={{ filter: 'sepia(1) saturate(2) hue-rotate(-5deg) brightness(1.05)' }}>📁</span>
+)
+
+// Three lowest-common-denominator buckets for object instances that aren't
+// FolderType. Driven by OPC UA's nodeClass when available (carried through on
+// metadata.system.nodeClass), with a typeId/sourceTypeId keyword fallback.
+const ObjectClassIcon = () => <span>📦</span>
+const VariableClassIcon = () => <span>📊</span>
+const OtherClassIcon = () => <span>⚙️</span>
+
+function bucketInstance(obj: ObjectInstance | undefined): 'object' | 'variable' | 'other' {
+  if (!obj) return 'other'
+  const sys = (obj.metadata?.system ?? {}) as Record<string, unknown>
+  const nodeClass = String(sys.nodeClass ?? '').toLowerCase()
+  if (nodeClass.startsWith('object')) return 'object'
+  if (nodeClass.startsWith('variable')) return 'variable'
+  if (nodeClass) return 'other'
+  // Fallback when nodeClass isn't reported: heuristic on typeId / sourceTypeId.
+  const t = `${obj.typeId} ${String(obj.metadata?.sourceTypeId ?? '')}`.toLowerCase()
+  if (/(variable|tag|datapoint|dataitem|measurement|sensor)/.test(t)) return 'variable'
+  if (/(object|device|equipment|asset|machine|component)/.test(t)) return 'object'
+  return 'other'
+}
 const NamespaceIcon = () => <span className="text-i3x-primary">🌐</span>
 const TypeIcon = () => <span className="text-i3x-success">📃</span>
-const CompositionObjectIcon = () => <span className="text-i3x-secondary">📦</span>
-const EmptyCompositionObjectIcon = () => (
-  <span style={{ filter: 'grayscale(1)', opacity: 0.6 }}>📦</span>
-)
-const LeafObjectIcon = () => <span className="text-i3x-secondary">🗒️</span>
 const ChevronRight = () => <span className="text-i3x-text-muted">›</span>
 const ChevronDown = () => <span className="text-i3x-text-muted">⌄</span>
 
@@ -171,14 +193,29 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
     switch (type) {
       case 'namespace':
         return <NamespaceIcon />
-      case 'objectType':
+      case 'objectType': {
+        // ObjectType definitions whose source resolves to OPC UA FolderType
+        // render as a folder.
+        const t = data as ObjectType | undefined
+        const src = (t?.sourceTypeId ?? '').toLowerCase()
+        const id = (t?.elementId ?? '').toLowerCase()
+        if (src.includes('foldertype') || id.includes('foldertype')) return <FolderTypeIcon />
         return <TypeIcon />
+      }
       case 'object': {
         const obj = data as ObjectInstance | undefined
-        if (obj?.isComposition) {
-          return hasChildren ? <CompositionObjectIcon /> : <EmptyCompositionObjectIcon />
+        // FolderType instances always render as a folder.
+        const typeId = (obj?.typeId ?? '').toLowerCase()
+        const metaSrc = String(obj?.metadata?.sourceTypeId ?? '').toLowerCase()
+        if (typeId.includes('foldertype') || metaSrc.includes('foldertype')) {
+          return <FolderTypeIcon />
         }
-        return <LeafObjectIcon />
+        // Otherwise bucket into one of three lowest-common-denominator classes.
+        switch (bucketInstance(obj)) {
+          case 'object': return <ObjectClassIcon />
+          case 'variable': return <VariableClassIcon />
+          default: return <OtherClassIcon />
+        }
       }
       case 'folder':
         return <FolderIcon />
@@ -192,10 +229,6 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
         style={{ paddingLeft: `${depth * 16 + 8}px` }}
         onClick={handleClick}
       >
-        {/* Non-root nodes: count rendered to the left of the chevron */}
-        {type !== 'folder' && count !== undefined && (
-          <span className="text-sm text-i3x-text-muted/60 tabular-nums flex-shrink-0">{count}</span>
-        )}
         {hasChildren && (
           <span className="w-4 flex-shrink-0">
             {isExpanded ? <ChevronDown /> : <ChevronRight />}
@@ -203,13 +236,24 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
         )}
         {!hasChildren && <span className="w-4" />}
         <span className="flex-shrink-0">{getIcon()}</span>
-        <span className="truncate text-sm">
-          {label}
-          {/* Root folders: count rendered after the label */}
-          {type === 'folder' && count !== undefined && (
-            <span className="ml-1.5 text-i3x-text-muted/60 tabular-nums">{count}</span>
-          )}
-        </span>
+        <span className="truncate text-sm">{label}</span>
+        {/* All counts render on the right edge of the row. Leader line is
+            solid when the row is expanded (the count is "active"), dashed
+            otherwise. */}
+        {count !== undefined && (
+          <>
+            <div
+              className={`flex-1 self-center mx-2 h-0 border-t ${
+                isExpanded
+                  ? 'border-solid border-i3x-text-muted/40'
+                  : 'border-dashed border-i3x-text-muted/25'
+              }`}
+            />
+            <span className="pr-2 text-sm text-i3x-text-muted/60 tabular-nums flex-shrink-0">
+              {count}
+            </span>
+          </>
+        )}
       </div>
       {isExpanded && children}
     </div>
@@ -219,13 +263,14 @@ function TreeNode({ id, label, type, data, depth, hasChildren, count, children }
 // Max depth for tree rendering to prevent infinite loops
 const MAX_TREE_DEPTH = 20
 
-// Chevron predicate: consult the compositionCache, which holds the answer
-// resolved via batched /objects/related. If we haven't resolved this object
-// yet, fall back to its isComposition flag (chevron may show momentarily).
-function hasCompositionChildren(obj: ObjectInstance, cache: Map<string, boolean>): boolean {
+// Chevron predicate: consult the compositionCache, which holds the actual
+// child count resolved via batched /objects/related. If we haven't resolved
+// this object yet, fall back to its isComposition flag (chevron may show
+// momentarily until the resolver lands).
+function hasCompositionChildren(obj: ObjectInstance, cache: Map<string, number>): boolean {
   if (!obj.isComposition) return false
   const cached = cache.get(obj.elementId)
-  return cached ?? true
+  return cached === undefined ? true : cached > 0
 }
 
 // Get display label for an object, handling special cases like root "/"
@@ -274,10 +319,15 @@ function ObjectNode({
   const childAncestors = new Set(ancestors)
   childAncestors.add(obj.elementId)
 
+  // Count: prefer the loaded children array (post-expansion); fall back to the
+  // resolver-populated cache for unexpanded compositional objects.
+  const cachedCount = compositionCache.get(obj.elementId)
+  const childCount = children.length > 0 ? children.length : cachedCount
   return (
     <TreeNode
       id={`obj:${obj.elementId}`}
       label={getObjectLabel(obj)}
+      count={childCount && childCount > 0 ? childCount : undefined}
       type="object"
       data={obj}
       depth={depth}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,5 +9,7 @@ interface Window {
     encryptString: (plaintext: string) => Promise<string | null>
     decryptString: (encrypted: string) => Promise<string | null>
     openDevTools: () => Promise<void>
+    onAppBeforeQuit: (callback: () => void) => () => void
+    notifyCleanupDone: () => void
   }
 }

--- a/src/stores/explorer.ts
+++ b/src/stores/explorer.ts
@@ -26,6 +26,11 @@ interface ExplorerState {
   allObjects: ObjectInstance[] // flat list of all objects
   hierarchicalRoots: ObjectInstance[] // root objects for the Hierarchy folder (from root=true query)
   childObjects: Map<string, ObjectInstance[]> // keyed by parent elementId
+  // elementId → "does this object have any qualifying compositional children
+  // (i.e. children where isComposition && parentId === this elementId)?".
+  // Resolved authoritatively via batched POST /objects/related so it never
+  // disagrees with the render filter applied at expansion time.
+  compositionCache: Map<string, boolean>
   expandedNodes: Set<string>
   selectedItem: SelectedItem | null
   isLoading: boolean
@@ -39,6 +44,7 @@ interface ExplorerState {
   setAllObjects: (objects: ObjectInstance[]) => void
   setHierarchicalRoots: (roots: ObjectInstance[]) => void
   setChildObjects: (parentId: string, children: ObjectInstance[]) => void
+  mergeCompositionFlags: (entries: Iterable<[string, boolean]>) => void
   toggleNode: (nodeId: string) => void
   expandNode: (nodeId: string) => void
   collapseNode: (nodeId: string) => void
@@ -57,6 +63,7 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
   allObjects: [],
   hierarchicalRoots: [],
   childObjects: new Map(),
+  compositionCache: new Map(),
   expandedNodes: new Set(),
   selectedItem: null,
   isLoading: false,
@@ -82,6 +89,13 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
     const updated = new Map(current)
     updated.set(parentId, children)
     set({ childObjects: updated })
+  },
+
+  mergeCompositionFlags: (entries) => {
+    const current = get().compositionCache
+    const updated = new Map(current)
+    for (const [id, flag] of entries) updated.set(id, flag)
+    set({ compositionCache: updated })
   },
 
   toggleNode: (nodeId) => {
@@ -122,6 +136,7 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
     allObjects: [],
     hierarchicalRoots: [],
     childObjects: new Map(),
+    compositionCache: new Map(),
     expandedNodes: new Set(),
     selectedItem: null,
     isLoading: false,

--- a/src/stores/explorer.ts
+++ b/src/stores/explorer.ts
@@ -26,11 +26,11 @@ interface ExplorerState {
   allObjects: ObjectInstance[] // flat list of all objects
   hierarchicalRoots: ObjectInstance[] // root objects for the Hierarchy folder (from root=true query)
   childObjects: Map<string, ObjectInstance[]> // keyed by parent elementId
-  // elementId → "does this object have any qualifying compositional children
-  // (i.e. children where isComposition && parentId === this elementId)?".
-  // Resolved authoritatively via batched POST /objects/related so it never
-  // disagrees with the render filter applied at expansion time.
-  compositionCache: Map<string, boolean>
+  // elementId → count of qualifying compositional children (children where
+  // isComposition && parentId === this elementId). Resolved authoritatively
+  // via batched POST /objects/related so it never disagrees with the render
+  // filter applied at expansion time. Also drives chevron state (count > 0).
+  compositionCache: Map<string, number>
   expandedNodes: Set<string>
   selectedItem: SelectedItem | null
   isLoading: boolean
@@ -44,7 +44,7 @@ interface ExplorerState {
   setAllObjects: (objects: ObjectInstance[]) => void
   setHierarchicalRoots: (roots: ObjectInstance[]) => void
   setChildObjects: (parentId: string, children: ObjectInstance[]) => void
-  mergeCompositionFlags: (entries: Iterable<[string, boolean]>) => void
+  mergeCompositionFlags: (entries: Iterable<[string, number]>) => void
   toggleNode: (nodeId: string) => void
   expandNode: (nodeId: string) => void
   collapseNode: (nodeId: string) => void

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -122,6 +122,7 @@ html, body, #root {
   @apply bg-i3x-border hover:bg-i3x-primary transition-colors cursor-col-resize;
 }
 
+
 .resize-handle-horizontal {
   @apply cursor-row-resize;
 }


### PR DESCRIPTION
## Summary

A cluster of tree-view improvements built on the existing namespace / objects / hierarchy structure, plus a small Electron quality-of-life pair.

### Tree
- **Authoritative chevron state**: branches that have no expandable children no longer show a chevron. Resolved via batched `POST /objects/related` at layer-load time, using the same predicate the render filter applies on expand. The previous behaviour was "show a chevron whenever `isComposition: true`," which produced empty expansions.
- **Sticky filter bar** at the top of the tree panel, wired to the existing `searchQuery` store.
- **Deep-match filtering**: searching for an object surfaces its parent namespace / type / hierarchy ancestors (precomputed visibility sets — `matchingTypeIds`, `hierarchyVisibleIds`, `matchedNamespaceUris`). Top-level folders auto-expand on search.
- **Per-level object counts** on Namespaces, Objects, Hierarchy folders + on each namespace, type, hierarchy node, and compositional object. Memoized group-by from already-loaded `allObjects`; zero new requests.
- **Leader line** between label and count: dashed when collapsed, solid when expanded.
- **Five-icon system** for object instances:
  - 🗄️ root folders (Namespaces / Objects / Hierarchy)
  - 📁 FolderType instances (manilla-tinted to render correctly across platforms)
  - 📦 NodeClass = Object
  - 📊 NodeClass = Variable
  - ⚙️ everything else
  - Bucketing prefers `metadata.system.nodeClass`, falls back to typeId / sourceTypeId keyword match.
- **Object counts pre-fetched** after connect (fire-and-forget) so the count badges appear before the user expands a folder.

### Electron
- DevTools button toggles instead of always opening.
- Graceful shutdown: main process holds `before-quit` until the renderer reports it has deleted active server-side subscriptions (3s safety timeout).

### Misc
- README features section refreshed to describe the current UI.
- `.gitignore` extended to cover the whole `.claude/` directory.