### PR TITLE
fix: subscription timeout recovery on server-side expiry

### DIFF
--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -87,7 +87,13 @@ export class SSESubscription {
       })
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+        const err = new Error(`HTTP ${response.status}: ${response.statusText}`)
+        // 404/410 means the subscription is gone — retrying will always fail
+        if (response.status === 404 || response.status === 410) {
+          this.onError(err)
+          return
+        }
+        throw err
       }
 
       if (!response.body) {

--- a/src/components/subscriptions/SubscriptionPanel.tsx
+++ b/src/components/subscriptions/SubscriptionPanel.tsx
@@ -12,7 +12,9 @@ export function SubscriptionPanel() {
     liveValues,
     activeSubscriptionId,
     setActiveSubscription,
+    addSubscription,
     removeSubscription,
+    removeMonitoredItem,
     updateLiveValue,
     setStreaming,
     clearAll
@@ -56,6 +58,38 @@ export function SubscriptionPanel() {
     })
   }
 
+  const handleRecovery = async (oldSubscriptionId: string) => {
+    const client = getClient()
+    if (!client) return
+
+    console.warn(`Subscription ${oldSubscriptionId} expired on server, recovering...`)
+
+    const { subscriptions: currentSubs } = useSubscriptionsStore.getState()
+    const oldSub = currentSubs.get(oldSubscriptionId)
+    const monitoredItems = oldSub?.monitoredItems ?? []
+
+    monitoredItems.forEach((elementId) => {
+      removeMonitoredItem(oldSubscriptionId, elementId)
+    })
+    removeSubscription(oldSubscriptionId)
+
+    try {
+      const { subscriptionId: newId } = await client.createSubscription()
+      if (monitoredItems.length > 0) {
+        await client.registerMonitoredItems(newId, monitoredItems)
+      }
+      addSubscription({
+        id: newId,
+        createdAt: new Date().toISOString(),
+        monitoredItems,
+        isStreaming: false
+      })
+      await handleStartStream(newId)
+    } catch (err) {
+      console.error('Subscription recovery failed:', err)
+    }
+  }
+
   const handleStartStream = async (subscriptionId: string) => {
     const client = getClient()
     if (!client) return
@@ -70,8 +104,12 @@ export function SubscriptionPanel() {
         () => client.sync(subscriptionId),
         handleDataUpdate,
         (error) => {
-          console.error('Polling error:', error)
-          setStreaming(subscriptionId, false)
+          if (error.message.includes('HTTP 404') || error.message.includes('HTTP 410')) {
+            handleRecovery(subscriptionId)
+          } else {
+            console.error('Polling error:', error)
+            setStreaming(subscriptionId, false)
+          }
         },
         2000 // Poll every 2 seconds
       )
@@ -84,8 +122,12 @@ export function SubscriptionPanel() {
         streamConfig.url,
         handleDataUpdate,
         (error) => {
-          console.error('SSE error:', error)
-          setStreaming(subscriptionId, false)
+          if (error.message.includes('HTTP 404') || error.message.includes('HTTP 410')) {
+            handleRecovery(subscriptionId)
+          } else {
+            console.error('SSE error:', error)
+            setStreaming(subscriptionId, false)
+          }
         },
         client.getCredentials(),
         streamConfig.postBody
@@ -106,12 +148,15 @@ export function SubscriptionPanel() {
     const client = getClient()
     if (!client) return
 
+    // Stop transport first to close timer-fire race window
+    sseRef.current?.disconnect()
+    sseRef.current = null
+    pollingRef.current?.stop()
+    pollingRef.current = null
+
     try {
-      await client.deleteSubscription(subscriptionId)
-      if (subscriptions.get(subscriptionId)?.isStreaming) {
-        sseRef.current?.disconnect()
-      }
       removeSubscription(subscriptionId)
+      await client.deleteSubscription(subscriptionId)
     } catch (err) {
       console.error('Failed to delete subscription:', err)
     }


### PR DESCRIPTION
Closes #29

## Summary

When a subscription expires on the server (404 on SSE stream or polling sync), the client previously entered a retry loop and never recovered — requiring a manual delete and re-subscribe. This PR adds silent automatic recovery: the stale subscription is torn down, a new one is created on the server, the same monitored items are re-registered, and streaming resumes transparently.

It also fixes two pre-existing bugs in `handleDelete` that were contributing to the infinite retry loop described in #29.

## Design Decisions

- **Recovery lives in `SubscriptionPanel` via the existing `onError` callback** — no transport layer changes needed beyond the 404 short-circuit. Keeps `SSESubscription` as a dumb transport with no knowledge of the store or client.
- **SSE 404 bypasses the reconnect loop** — previously a 404 from `startFetch()` went through `handleDisconnect()`, scheduling retries that would always fail. Now 404/410 calls `onError` directly and returns, stopping the loop immediately.
- **Polling recovery uses the same mechanism** — `PollingSubscription` errors propagate directly to `onError`, so the same `"HTTP 404"` check works for both transports.
- **`liveValues` cleared per-item before store teardown** — `removeMonitoredItem` atomically removes from both `subscriptions` and `liveValues` maps; it must be called before `removeSubscription` or it becomes a no-op.

## Changes

### Phase 1: Fix `handleDelete` bugs (`SubscriptionPanel.tsx`)
- Transport (`sseRef`, `pollingRef`) is now disconnected and nulled **before** the network call — closes the timer-fire race window where a queued reconnect could fire during `await client.deleteSubscription()`
- `pollingRef.current?.stop()` added unconditionally — was previously never called, leaking the `setInterval` until component unmount
- `removeSubscription` moved before `await client.deleteSubscription()` — store cleaned up immediately so any in-flight timer can't trigger recovery for an already-deleted subscription

### Phase 2: `handleRecovery` + 404 detection (`SubscriptionPanel.tsx`, `subscription.ts`)
- `SSESubscription.startFetch()`: 404/410 now calls `onError` directly and returns, bypassing `handleDisconnect()` — this is the root fix for the infinite retry loop
- `handleRecovery(oldSubscriptionId)`: captures `monitoredItems` from store, clears stale live values, tears down old subscription, creates new subscription on server, re-registers items, resumes streaming
- Both SSE and polling `onError` callbacks: `"HTTP 404"` triggers `handleRecovery`; all other errors retain original behaviour (`console.error` + `setStreaming(false)`)

## Testing

- TypeScript typecheck passes (`npm run typecheck`)
- No test suite in this repo — manual verification:
  1. Connect, subscribe to objects, start streaming
  2. Delete the subscription server-side out-of-band (e.g. server restart)
  3. Observe: `console.warn` with "expired on server, recovering...", subscription panel shows new ID, live values resume
  4. Confirm non-404 errors (e.g. server killed mid-stream) still log correctly with no recovery attempt

## Rollback

```bash
git revert b01226459259e3e46856d241a6bdc3bb25674bdc
```

No store interface changes, no new files, no migration needed.