### PR TITLE
feat(tree): improve rendering performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,9 +158,9 @@ The `scripts/generate-icons.sh` script generates platform-specific icons:
 - Connect to I3X servers (default: https://api.i3x.dev/v1)
 - Ignore certificate errors checkbox in connection dialog (Electron only) — for self-signed / dev servers; persisted across restarts
 - Browse hierarchical tree: Namespaces → ObjectTypes → Objects
-- Browse flat Objects list (lazy-loaded)
+- Browse flat Objects list (lazy-loaded, virtualized — only rows near the viewport are mounted, so tens of thousands of objects stay responsive)
 - Expand compositional objects to see children
-- Tree auto-refresh: expanding a branch always re-fetches from the server; 30s background poll refreshes all expanded branches
+- Tree auto-refresh: expanding a branch re-fetches from the server (full-catalog refetches are coalesced/throttled on large sets); 30s background poll refreshes all expanded branches
 - View object details, metadata, and current values
 - Current Value pane has a **Parsed / Raw** toggle — Raw shows the untouched HTTP response body; for composition objects the component rows middle-truncate the elementId and round numeric values, with full id/value/timestamp on hover
 - Copy-to-clipboard floating icon on every JSON pane (object data, schema, raw value, etc.)
@@ -432,9 +432,13 @@ location / {
 ```
 
 ### Tree Refresh
-- Expanding any branch always re-fetches from the server (no stale cache)
-- Hierarchy nodes (`hier:` prefix) re-fetch `allObjects` on expand — important for MQTT adapters that discover objects dynamically as topics arrive
+- Expanding any branch re-fetches from the server (no stale cache)
+- Hierarchy nodes (`hier:` prefix) re-fetch `allObjects` on expand — important for MQTT adapters that discover objects dynamically as topics arrive. These full-catalog refetches are coalesced/throttled (`refreshAllObjects` in `TreeView.tsx`, `ALL_OBJECTS_REFETCH_TTL_MS`): concurrent expands share one in-flight request and a fresh fetch is skipped if one ran within the window, so rapidly expanding many nodes on a large catalog doesn't trigger a full refetch per click. Opening the Objects/Hierarchy folder and the background poll force a fresh fetch, so freshness is preserved.
 - A 30-second background poll refreshes all currently-expanded branches while connected (controlled by `BACKGROUND_POLL_ENABLED` in `TreeView.tsx`)
+- `allObjects` is indexed by `parentId` into `childrenByParent` in the store when set, so the hierarchy view resolves each node's children with an O(1) map lookup instead of scanning the full object list per node. `objectTypes` is likewise indexed into `typeIndex` (shared by every node for icon bucketing). Tree nodes use narrow store selectors so a single node's expand/select doesn't re-render the whole tree.
+- The tree is split into focused modules under `src/components/tree/`: `treeData.ts` (non-JSX shared logic — `resolveCompositionFlags`, `refreshAllObjects`, `flattenObjectForest`, `hasCompositionChildren`, `getObjectLabel`, folder-id/`MAX_TREE_DEPTH` constants), `TreeNode.tsx` (the leaf row component + icons), `VirtualObjectRows.tsx` (the windowed Objects list), and `TreeView.tsx` (`ObjectNode`, `HierarchicalObjectNode`, and the `TreeView` shell). Dependencies point one way into `treeData`/`TreeNode`, so there is no import cycle.
+- The flat Objects folder is **virtualized** (`VirtualObjectRows` in `src/components/tree/VirtualObjectRows.tsx`, using `@tanstack/react-virtual`). Its visible forest (flat objects plus any expanded compositional descendants) is flattened into one linear array by `flattenObjectForest` and windowed against the shared tree scroll container via `scrollMargin`, so only rows in/near the viewport mount — a catalog of tens of thousands of objects no longer renders every row at once. Rows render in normal flow with top/bottom spacer padding (not absolute positioning) so the existing horizontal scroll, hover, selection, and count leader-lines are preserved; row height is measured once from the first mounted row. Expansion state lives in the store, so expanded rows survive being scrolled out of the window.
+- **Composition chevrons resolve lazily for the visible window.** `hasCompositionChildren` shows a chevron optimistically for any unresolved `isComposition` object; `VirtualObjectRows` then resolves the real qualifying-child count for the rows currently in view (small debounced `resolveCompositionFlags` batch), so a composition object whose components are all leaves loses its (dead) chevron without the user clicking. The whole catalog is never resolved in one batch (that batch is slow/unreliable at 58k and left chevrons wrong). Expanding an object also writes its real child count back to the cache, so a click self-corrects the chevron as a backstop.
 
 ### Theme System
 - Colors are defined as CSS custom properties (space-separated RGB channels) in `src/styles/index.css`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.14.5",
         "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2098,6 +2099,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.5",
     "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -1,0 +1,238 @@
+import { useCallback } from 'react'
+import { useExplorerStore, type SelectedItem } from '../../stores/explorer'
+import { getClient } from '../../api/client'
+import type { Namespace, ObjectType, ObjectInstance } from '../../api/types'
+import {
+  resolveCompositionFlags,
+  refreshAllObjects,
+  OBJECTS_FOLDER_ID,
+  HIERARCHICAL_FOLDER_ID,
+} from './treeData'
+
+// Icons
+const FolderIcon = () => (
+  <span style={{ filter: 'sepia(1) saturate(1.6) hue-rotate(-15deg) brightness(0.89)' }}>🗄️</span>
+)
+// 📁 emoji renders grey on some macOS configurations; sepia/saturate filter
+// forces a manilla tint while keeping the emoji aesthetic of the rest of the
+// tree.
+const FolderTypeIcon = () => (
+  <span style={{ filter: 'sepia(1) saturate(2) hue-rotate(-5deg) brightness(1.05)' }}>📁</span>
+)
+
+// Three lowest-common-denominator buckets for object instances that aren't
+// FolderType. Driven by OPC UA's nodeClass when available (carried through on
+// metadata.system.nodeClass), with a typeId/sourceTypeId keyword fallback.
+const ObjectClassIcon = () => <span>📦</span>
+const VariableClassIcon = () => <span>📊</span>
+
+const SCALAR_TYPES = new Set(['number', 'integer', 'string', 'boolean'])
+
+// Per the i3X Implementation Guide: schema.type is the sole authoritative leaf signal.
+// scalar type (number/integer/string/boolean) → leaf (📊); everything else → branch (📦).
+// schema.type may be a union array (e.g. ["number","null"]) — treat as leaf if any member is scalar.
+function bucketInstance(
+  obj: ObjectInstance | undefined,
+  typeIndex?: Map<string, ObjectType>
+): 'variable' | 'other' {
+  if (!obj) return 'other'
+  const raw = typeIndex?.get(obj.typeId)?.schema?.type
+  const schemaType = Array.isArray(raw)
+    ? (raw as string[]).find(t => SCALAR_TYPES.has(t)) ?? ''
+    : String(raw ?? '')
+  return SCALAR_TYPES.has(schemaType) ? 'variable' : 'other'
+}
+const NamespaceIcon = () => <span className="text-i3x-primary">🌐</span>
+const TypeIcon = () => <span className="text-i3x-success">📃</span>
+const ChevronRight = () => <span className="text-i3x-text-muted">›</span>
+const ChevronDown = () => <span className="text-i3x-text-muted">⌄</span>
+
+interface TreeNodeProps {
+  id: string
+  label: string
+  type: 'namespace' | 'objectType' | 'object' | 'folder'
+  data?: Namespace | ObjectType | ObjectInstance
+  depth: number
+  hasChildren?: boolean
+  // Optional minimalist count badge rendered to the right of the label —
+  // small, muted, no brackets. Only rendered when defined.
+  count?: number
+  children?: React.ReactNode
+}
+
+export function TreeNode({ id, label, type, data, depth, hasChildren, count, children }: TreeNodeProps) {
+  // Narrow selectors: a node re-renders only when its own expanded/selected
+  // state changes, not on every unrelated store update (live subscription
+  // values, cache merges, etc.). typeIndex is the shared map built once in the
+  // store, so nodes no longer each rebuild a Map over all object types.
+  const isExpanded = useExplorerStore(s => s.expandedNodes.has(id))
+  const isSelected = useExplorerStore(s => s.selectedItem?.id === id)
+  const typeIndex = useExplorerStore(s => s.typeIndex)
+
+  const handleClick = useCallback(async () => {
+    // Store actions are stable references; pull them at call time so they don't
+    // need to be selector subscriptions or effect/callback dependencies.
+    const { toggleNode, selectItem, setObjects, setHierarchicalRoots, setChildObjects, mergeCompositionFlags } = useExplorerStore.getState()
+    // Select the item
+    if (data && type !== 'folder') {
+      selectItem({ type, id, data } as SelectedItem)
+    }
+
+    // Toggle expansion
+    if (hasChildren) {
+      toggleNode(id)
+
+      // Re-fetch objects for this type whenever expanding (always fresh)
+      if (type === 'objectType' && !isExpanded) {
+        const client = getClient()
+        if (client) {
+          try {
+            const objectType = data as ObjectType
+            const objects = await client.getObjects(objectType.elementId)
+            await resolveCompositionFlags(client, objects)
+            setObjects(objectType.elementId, objects)
+          } catch (err) {
+            console.error('Failed to load objects:', err)
+          }
+        }
+      }
+
+      // Re-fetch all objects whenever expanding Objects or Hierarchy folder.
+      // Opening a folder forces a fresh fetch (bypasses the navigation throttle).
+      if ((id === OBJECTS_FOLDER_ID || id === HIERARCHICAL_FOLDER_ID) && !isExpanded) {
+        const client = getClient()
+        if (client) {
+          try {
+            await refreshAllObjects(client, true)
+          } catch (err) {
+            console.error('Failed to load all objects:', err)
+          }
+        }
+      }
+
+      // For the Hierarchy folder, also fetch root objects via root=true so the server
+      // determines what counts as a root (avoids relying on parentId === '/' locally)
+      if (id === HIERARCHICAL_FOLDER_ID && !isExpanded) {
+        const client = getClient()
+        if (client) {
+          try {
+            const roots = await client.getObjects(undefined, false, true)
+            await resolveCompositionFlags(client, roots)
+            setHierarchicalRoots(roots)
+          } catch (err) {
+            console.error('Failed to load root objects:', err)
+          }
+        }
+      }
+
+      // Re-fetch all objects when expanding a hierarchy node to pick up newly
+      // discovered objects. Throttled/coalesced so rapidly expanding many nodes
+      // doesn't trigger a full 58k-object refetch per click on large catalogs.
+      if (id.startsWith('hier:') && !isExpanded) {
+        const client = getClient()
+        if (client) {
+          try {
+            await refreshAllObjects(client)
+          } catch (err) {
+            console.error('Failed to refresh objects for hierarchy node:', err)
+          }
+        }
+      }
+
+      // Re-fetch child objects whenever expanding a compositional object (always fresh)
+      if (type === 'object' && !isExpanded && !id.startsWith('hier:')) {
+        const obj = data as ObjectInstance
+        if (obj.isComposition) {
+          const client = getClient()
+          if (client) {
+            try {
+              const related = await client.getRelatedObjects(obj.elementId, 'HasComponent')
+              const compositionalChildren = related.filter(child =>
+                child.isComposition &&
+                child.elementId !== obj.elementId &&
+                child.parentId === obj.elementId
+              )
+              await resolveCompositionFlags(client, compositionalChildren)
+              setChildObjects(obj.elementId, compositionalChildren)
+              // Reflect the real qualifying-child count on the parent so an
+              // optimistic chevron self-corrects to "no chevron" when a click
+              // reveals there is nothing to expand.
+              mergeCompositionFlags([[obj.elementId, compositionalChildren.length]])
+            } catch (err) {
+              console.error('Failed to load child objects:', err)
+            }
+          }
+        }
+      }
+    }
+  }, [data, type, id, hasChildren, isExpanded])
+
+  const getIcon = () => {
+    switch (type) {
+      case 'namespace':
+        return <NamespaceIcon />
+      case 'objectType': {
+        // ObjectType definitions whose source resolves to OPC UA FolderType
+        // render as a folder.
+        const t = data as ObjectType | undefined
+        const src = (t?.sourceTypeId ?? '').toLowerCase()
+        const id = (t?.elementId ?? '').toLowerCase()
+        if (src.includes('foldertype') || id.includes('foldertype')) return <FolderTypeIcon />
+        return <TypeIcon />
+      }
+      case 'object': {
+        const obj = data as ObjectInstance | undefined
+        // FolderType instances always render as a folder.
+        const typeId = (obj?.typeId ?? '').toLowerCase()
+        const metaSrc = String(obj?.metadata?.sourceTypeId ?? '').toLowerCase()
+        if (typeId.includes('foldertype') || metaSrc.includes('foldertype')) {
+          return <FolderTypeIcon />
+        }
+        // Otherwise bucket into one of three lowest-common-denominator classes.
+        switch (bucketInstance(obj, typeIndex)) {
+          case 'variable': return <VariableClassIcon />
+          default: return <ObjectClassIcon />
+        }
+      }
+      case 'folder':
+        return <FolderIcon />
+    }
+  }
+
+  return (
+    <div>
+      <div
+        className={`tree-node ${isSelected ? 'selected' : ''}`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={handleClick}
+      >
+        {hasChildren && (
+          <span className="w-4 flex-shrink-0">
+            {isExpanded ? <ChevronDown /> : <ChevronRight />}
+          </span>
+        )}
+        {!hasChildren && <span className="w-4" />}
+        <span className="flex-shrink-0">{getIcon()}</span>
+        <span className="whitespace-nowrap text-sm">{label}</span>
+        {/* All counts render on the right edge of the row. Leader line is
+            solid when the row is expanded (the count is "active"), dashed
+            otherwise. */}
+        {count !== undefined && (
+          <>
+            <div
+              className={`flex-1 self-center mx-2 h-0 border-t ${
+                isExpanded
+                  ? 'border-solid border-i3x-text-muted/40'
+                  : 'border-dashed border-i3x-text-muted/25'
+              }`}
+            />
+            <span className="pr-2 text-sm text-i3x-text-muted/60 tabular-nums flex-shrink-0">
+              {count}
+            </span>
+          </>
+        )}
+      </div>
+      {isExpanded && children}
+    </div>
+  )
+}

--- a/src/components/tree/TreeView.tsx
+++ b/src/components/tree/TreeView.tsx
@@ -1,292 +1,22 @@
-import { useCallback, useEffect, useMemo } from 'react'
-import { useExplorerStore, type SelectedItem } from '../../stores/explorer'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useExplorerStore } from '../../stores/explorer'
 import { useConnectionStore } from '../../stores/connection'
-import { getClient, type I3XClient } from '../../api/client'
-import type { Namespace, ObjectType, ObjectInstance } from '../../api/types'
-
-// After loading a layer of objects, decide chevron state for each compositional
-// parent by asking the server what /objects/related actually returns — i.e. the
-// same data the render filter sees at expansion time. Single batch round trip.
-// Awaiting this before committing layer state ensures chevrons render correctly
-// on first paint instead of flipping after a follow-up fetch.
-async function resolveCompositionFlags(client: I3XClient, loaded: ObjectInstance[]): Promise<void> {
-  if (loaded.length === 0) return
-  const { compositionCache, mergeCompositionFlags } = useExplorerStore.getState()
-  const toResolve: string[] = []
-  for (const obj of loaded) {
-    if (obj.isComposition && !compositionCache.has(obj.elementId)) {
-      toResolve.push(obj.elementId)
-    }
-  }
-  if (toResolve.length === 0) return
-  const additions = new Map<string, number>()
-  try {
-    const related = await client.getRelatedObjectsBatch(toResolve, 'HasComponent')
-    for (const parentId of toResolve) {
-      const children = related.get(parentId) ?? []
-      const qualifyingCount = children.filter(c =>
-        c.isComposition && c.elementId !== parentId && c.parentId === parentId
-      ).length
-      additions.set(parentId, qualifyingCount)
-    }
-  } catch (err) {
-    console.error('Failed to resolve composition flags via /objects/related:', err)
-  }
-  if (additions.size > 0) mergeCompositionFlags(additions)
-}
+import { getClient } from '../../api/client'
+import type { ObjectType, ObjectInstance } from '../../api/types'
+import { TreeNode } from './TreeNode'
+import { VirtualObjectRows } from './VirtualObjectRows'
+import {
+  resolveCompositionFlags,
+  refreshAllObjects,
+  hasCompositionChildren,
+  getObjectLabel,
+  MAX_TREE_DEPTH,
+  NAMESPACES_FOLDER_ID,
+  OBJECTS_FOLDER_ID,
+  HIERARCHICAL_FOLDER_ID,
+} from './treeData'
 
 const BACKGROUND_POLL_ENABLED = true
-
-// Icons
-const FolderIcon = () => (
-  <span style={{ filter: 'sepia(1) saturate(1.6) hue-rotate(-15deg) brightness(0.89)' }}>🗄️</span>
-)
-// 📁 emoji renders grey on some macOS configurations; sepia/saturate filter
-// forces a manilla tint while keeping the emoji aesthetic of the rest of the
-// tree.
-const FolderTypeIcon = () => (
-  <span style={{ filter: 'sepia(1) saturate(2) hue-rotate(-5deg) brightness(1.05)' }}>📁</span>
-)
-
-// Three lowest-common-denominator buckets for object instances that aren't
-// FolderType. Driven by OPC UA's nodeClass when available (carried through on
-// metadata.system.nodeClass), with a typeId/sourceTypeId keyword fallback.
-const ObjectClassIcon = () => <span>📦</span>
-const VariableClassIcon = () => <span>📊</span>
-
-const SCALAR_TYPES = new Set(['number', 'integer', 'string', 'boolean'])
-
-// Per the i3X Implementation Guide: schema.type is the sole authoritative leaf signal.
-// scalar type (number/integer/string/boolean) → leaf (📊); everything else → branch (📦).
-// schema.type may be a union array (e.g. ["number","null"]) — treat as leaf if any member is scalar.
-function bucketInstance(
-  obj: ObjectInstance | undefined,
-  typeIndex?: Map<string, ObjectType>
-): 'variable' | 'other' {
-  if (!obj) return 'other'
-  const raw = typeIndex?.get(obj.typeId)?.schema?.type
-  const schemaType = Array.isArray(raw)
-    ? (raw as string[]).find(t => SCALAR_TYPES.has(t)) ?? ''
-    : String(raw ?? '')
-  return SCALAR_TYPES.has(schemaType) ? 'variable' : 'other'
-}
-const NamespaceIcon = () => <span className="text-i3x-primary">🌐</span>
-const TypeIcon = () => <span className="text-i3x-success">📃</span>
-const ChevronRight = () => <span className="text-i3x-text-muted">›</span>
-const ChevronDown = () => <span className="text-i3x-text-muted">⌄</span>
-
-// Special folder IDs
-const NAMESPACES_FOLDER_ID = 'folder:namespaces'
-const OBJECTS_FOLDER_ID = 'folder:objects'
-const HIERARCHICAL_FOLDER_ID = 'folder:hierarchical'
-
-interface TreeNodeProps {
-  id: string
-  label: string
-  type: 'namespace' | 'objectType' | 'object' | 'folder'
-  data?: Namespace | ObjectType | ObjectInstance
-  depth: number
-  hasChildren?: boolean
-  // Optional minimalist count badge rendered to the right of the label —
-  // small, muted, no brackets. Only rendered when defined.
-  count?: number
-  children?: React.ReactNode
-}
-
-function TreeNode({ id, label, type, data, depth, hasChildren, count, children }: TreeNodeProps) {
-  const { expandedNodes, selectedItem, toggleNode, selectItem, setObjects, setAllObjects, setHierarchicalRoots, setChildObjects, objectTypes } = useExplorerStore()
-
-  const isExpanded = expandedNodes.has(id)
-  const isSelected = selectedItem?.id === id
-
-  const typeIndex = useMemo(
-    () => new Map(objectTypes.map(t => [t.elementId, t])),
-    [objectTypes]
-  )
-
-  const handleClick = useCallback(async () => {
-    // Select the item
-    if (data && type !== 'folder') {
-      selectItem({ type, id, data } as SelectedItem)
-    }
-
-    // Toggle expansion
-    if (hasChildren) {
-      toggleNode(id)
-
-      // Re-fetch objects for this type whenever expanding (always fresh)
-      if (type === 'objectType' && !isExpanded) {
-        const client = getClient()
-        if (client) {
-          try {
-            const objectType = data as ObjectType
-            const objects = await client.getObjects(objectType.elementId)
-            await resolveCompositionFlags(client, objects)
-            setObjects(objectType.elementId, objects)
-          } catch (err) {
-            console.error('Failed to load objects:', err)
-          }
-        }
-      }
-
-      // Re-fetch all objects whenever expanding Objects or Hierarchy folder (always fresh)
-      if ((id === OBJECTS_FOLDER_ID || id === HIERARCHICAL_FOLDER_ID) && !isExpanded) {
-        const client = getClient()
-        if (client) {
-          try {
-            const objects = await client.getObjects()
-            await resolveCompositionFlags(client, objects)
-            setAllObjects(objects)
-          } catch (err) {
-            console.error('Failed to load all objects:', err)
-          }
-        }
-      }
-
-      // For the Hierarchy folder, also fetch root objects via root=true so the server
-      // determines what counts as a root (avoids relying on parentId === '/' locally)
-      if (id === HIERARCHICAL_FOLDER_ID && !isExpanded) {
-        const client = getClient()
-        if (client) {
-          try {
-            const roots = await client.getObjects(undefined, false, true)
-            await resolveCompositionFlags(client, roots)
-            setHierarchicalRoots(roots)
-          } catch (err) {
-            console.error('Failed to load root objects:', err)
-          }
-        }
-      }
-
-      // Re-fetch all objects when expanding a hierarchy node (picks up newly discovered objects)
-      if (id.startsWith('hier:') && !isExpanded) {
-        const client = getClient()
-        if (client) {
-          try {
-            const objects = await client.getObjects()
-            await resolveCompositionFlags(client, objects)
-            setAllObjects(objects)
-          } catch (err) {
-            console.error('Failed to refresh objects for hierarchy node:', err)
-          }
-        }
-      }
-
-      // Re-fetch child objects whenever expanding a compositional object (always fresh)
-      if (type === 'object' && !isExpanded && !id.startsWith('hier:')) {
-        const obj = data as ObjectInstance
-        if (obj.isComposition) {
-          const client = getClient()
-          if (client) {
-            try {
-              const related = await client.getRelatedObjects(obj.elementId, 'HasComponent')
-              const compositionalChildren = related.filter(child =>
-                child.isComposition &&
-                child.elementId !== obj.elementId &&
-                child.parentId === obj.elementId
-              )
-              await resolveCompositionFlags(client, compositionalChildren)
-              setChildObjects(obj.elementId, compositionalChildren)
-            } catch (err) {
-              console.error('Failed to load child objects:', err)
-            }
-          }
-        }
-      }
-    }
-  }, [data, type, id, hasChildren, isExpanded, selectItem, toggleNode, setObjects, setAllObjects, setHierarchicalRoots, setChildObjects])
-
-  const getIcon = () => {
-    switch (type) {
-      case 'namespace':
-        return <NamespaceIcon />
-      case 'objectType': {
-        // ObjectType definitions whose source resolves to OPC UA FolderType
-        // render as a folder.
-        const t = data as ObjectType | undefined
-        const src = (t?.sourceTypeId ?? '').toLowerCase()
-        const id = (t?.elementId ?? '').toLowerCase()
-        if (src.includes('foldertype') || id.includes('foldertype')) return <FolderTypeIcon />
-        return <TypeIcon />
-      }
-      case 'object': {
-        const obj = data as ObjectInstance | undefined
-        // FolderType instances always render as a folder.
-        const typeId = (obj?.typeId ?? '').toLowerCase()
-        const metaSrc = String(obj?.metadata?.sourceTypeId ?? '').toLowerCase()
-        if (typeId.includes('foldertype') || metaSrc.includes('foldertype')) {
-          return <FolderTypeIcon />
-        }
-        // Otherwise bucket into one of three lowest-common-denominator classes.
-        switch (bucketInstance(obj, typeIndex)) {
-          case 'variable': return <VariableClassIcon />
-          default: return <ObjectClassIcon />
-        }
-      }
-      case 'folder':
-        return <FolderIcon />
-    }
-  }
-
-  return (
-    <div>
-      <div
-        className={`tree-node ${isSelected ? 'selected' : ''}`}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
-        onClick={handleClick}
-      >
-        {hasChildren && (
-          <span className="w-4 flex-shrink-0">
-            {isExpanded ? <ChevronDown /> : <ChevronRight />}
-          </span>
-        )}
-        {!hasChildren && <span className="w-4" />}
-        <span className="flex-shrink-0">{getIcon()}</span>
-        <span className="whitespace-nowrap text-sm">{label}</span>
-        {/* All counts render on the right edge of the row. Leader line is
-            solid when the row is expanded (the count is "active"), dashed
-            otherwise. */}
-        {count !== undefined && (
-          <>
-            <div
-              className={`flex-1 self-center mx-2 h-0 border-t ${
-                isExpanded
-                  ? 'border-solid border-i3x-text-muted/40'
-                  : 'border-dashed border-i3x-text-muted/25'
-              }`}
-            />
-            <span className="pr-2 text-sm text-i3x-text-muted/60 tabular-nums flex-shrink-0">
-              {count}
-            </span>
-          </>
-        )}
-      </div>
-      {isExpanded && children}
-    </div>
-  )
-}
-
-// Max depth for tree rendering to prevent infinite loops
-const MAX_TREE_DEPTH = 20
-
-// Chevron predicate: consult the compositionCache, which holds the actual
-// child count resolved via batched /objects/related. If we haven't resolved
-// this object yet, fall back to its isComposition flag (chevron may show
-// momentarily until the resolver lands).
-function hasCompositionChildren(obj: ObjectInstance, cache: Map<string, number>): boolean {
-  if (!obj.isComposition) return false
-  const cached = cache.get(obj.elementId)
-  return cached === undefined ? true : cached > 0
-}
-
-// Get display label for an object, handling special cases like root "/"
-function getObjectLabel(obj: ObjectInstance): string {
-  if (obj.displayName && obj.displayName.trim()) {
-    return obj.displayName
-  }
-  // Fallback to elementId for objects with empty displayName (e.g., root "/")
-  return obj.elementId
-}
 
 // Recursive component for rendering objects with their children
 function ObjectNode({
@@ -359,21 +89,22 @@ function HierarchicalObjectNode({
   obj,
   depth,
   filterText,
-  allObjects,
+  childrenByParent,
   visibleIds,
   ancestors = new Set<string>()
 }: {
   obj: ObjectInstance
   depth: number
   filterText: string
-  allObjects: ObjectInstance[]
+  childrenByParent: Map<string, ObjectInstance[]>
   // When filterText is active, set of object IDs that should remain visible
   // (matches + their ancestors). Computed once at the TreeView level.
   visibleIds?: Set<string>
   ancestors?: Set<string>
 }) {
-  // Find children by filtering allObjects where parentId matches this object
-  const children = allObjects.filter(child => child.parentId === obj.elementId)
+  // Direct children via the prebuilt parentId index (O(1) lookup instead of
+  // scanning the entire allObjects array on every node).
+  const children = childrenByParent.get(obj.elementId) ?? []
   const filteredChildren = filterText
     ? children.filter(child => visibleIds?.has(child.elementId))
     : children
@@ -409,7 +140,7 @@ function HierarchicalObjectNode({
           obj={child}
           depth={depth + 1}
           filterText={filterText}
-          allObjects={allObjects}
+          childrenByParent={childrenByParent}
           visibleIds={visibleIds}
           ancestors={childAncestors}
         />
@@ -419,14 +150,33 @@ function HierarchicalObjectNode({
 }
 
 export function TreeView() {
-  const { namespaces, objectTypes, objects, allObjects, hierarchicalRoots, searchQuery, setSearchQuery, pollIntervalMs, manualRefreshTick } = useExplorerStore()
+  // Narrow selectors so the tree re-renders only for the slices it uses, not on
+  // every unrelated store update (e.g. live subscription values).
+  const namespaces = useExplorerStore(s => s.namespaces)
+  const objectTypes = useExplorerStore(s => s.objectTypes)
+  const objects = useExplorerStore(s => s.objects)
+  const allObjects = useExplorerStore(s => s.allObjects)
+  const hierarchicalRoots = useExplorerStore(s => s.hierarchicalRoots)
+  const childrenByParent = useExplorerStore(s => s.childrenByParent)
+  const searchQuery = useExplorerStore(s => s.searchQuery)
+  const setSearchQuery = useExplorerStore(s => s.setSearchQuery)
+  const pollIntervalMs = useExplorerStore(s => s.pollIntervalMs)
+  const manualRefreshTick = useExplorerStore(s => s.manualRefreshTick)
+  // Only the flat Objects folder needs to know its own expansion state here, so
+  // its (potentially huge) child list is filtered/built only while it is open.
+  const objectsExpanded = useExplorerStore(s => s.expandedNodes.has(OBJECTS_FOLDER_ID))
   const isConnected = useConnectionStore(state => state.isConnected)
+
+  // Shared scroll container + content wrapper, referenced by the virtualized
+  // Objects list to window its rows and track its offset within the scroll area.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
 
   const refreshTree = useCallback(async () => {
     const client = getClient()
     if (!client) return
 
-    const { expandedNodes, setNamespaces, setObjectTypes, setObjects, setAllObjects, setHierarchicalRoots, setChildObjects } = useExplorerStore.getState()
+    const { expandedNodes, setNamespaces, setObjectTypes, setObjects, setHierarchicalRoots, setChildObjects } = useExplorerStore.getState()
 
     try {
       const [namespaces, objectTypes] = await Promise.all([
@@ -457,9 +207,7 @@ export function TreeView() {
       if ((nodeId === OBJECTS_FOLDER_ID || nodeId === HIERARCHICAL_FOLDER_ID) && !allObjectsRefreshed) {
         allObjectsRefreshed = true
         try {
-          const objects = await client.getObjects()
-          await resolveCompositionFlags(client, objects)
-          setAllObjects(objects)
+          await refreshAllObjects(client, true)
         } catch (err) {
           console.error('Background refresh: all objects failed', err)
         }
@@ -584,8 +332,19 @@ export function TreeView() {
     }
   })
 
-  // Filter all objects for the Objects folder (flat list — only direct matches)
-  const filteredAllObjects = allObjects.filter(obj => !filterText || objMatches(obj))
+  // Filter all objects for the Objects folder (flat list — only direct matches).
+  // Materialized only while the Objects folder is open: with tens of thousands
+  // of objects, filtering and building this array on every render is a large
+  // cost that would otherwise be paid even while the folder is collapsed.
+  const filteredAllObjects = useMemo(() => {
+    if (!objectsExpanded) return [] as ObjectInstance[]
+    if (!filterText) return allObjects
+    return allObjects.filter(obj =>
+      obj.displayName.toLowerCase().includes(filterText) ||
+      obj.elementId.toLowerCase().includes(filterText) ||
+      obj.namespaceUri.toLowerCase().includes(filterText)
+    )
+  }, [objectsExpanded, filterText, allObjects])
 
   const filteredHierarchicalRoots = hierarchicalRoots.filter(
     obj => !filterText || hierarchyVisibleIds.has(obj.elementId)
@@ -621,8 +380,8 @@ export function TreeView() {
           widest row so long labels/deep nesting extend a horizontal scrollbar,
           while min-w-full keeps rows (highlights, count leader-lines) panel-wide
           when content fits. */}
-      <div className="flex-1 min-h-0 overflow-auto">
-       <div className="w-max min-w-full">
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto">
+       <div ref={contentRef} className="w-max min-w-full">
       {/* Namespaces folder */}
       <TreeNode
         id={NAMESPACES_FOLDER_ID}
@@ -694,14 +453,12 @@ export function TreeView() {
          depth={0}
          hasChildren={true}
        >
-         {filteredAllObjects.map((obj) => (
-           <ObjectNode
-             key={`all-${obj.elementId}`}
-             obj={obj}
-             depth={1}
-             filterText={filterText}
-           />
-         ))}
+         <VirtualObjectRows
+           roots={filteredAllObjects}
+           scrollRef={scrollRef}
+           contentRef={contentRef}
+           filterText={filterText}
+         />
          {allObjects.length > 0 && filteredAllObjects.length === 0 && (
            <div className="text-i3x-text-muted text-sm py-2 pl-8">
              No matching objects
@@ -724,7 +481,7 @@ export function TreeView() {
             obj={obj}
             depth={1}
             filterText={filterText}
-            allObjects={allObjects}
+            childrenByParent={childrenByParent}
             visibleIds={hierarchyVisibleIds}
           />
         ))}

--- a/src/components/tree/VirtualObjectRows.tsx
+++ b/src/components/tree/VirtualObjectRows.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useExplorerStore } from '../../stores/explorer'
+import { getClient } from '../../api/client'
+import type { ObjectInstance } from '../../api/types'
+import { TreeNode } from './TreeNode'
+import { flattenObjectForest, resolveCompositionFlags, getObjectLabel, ESTIMATED_ROW_HEIGHT } from './treeData'
+
+const TREE_INDENT_PX = 16
+const TREE_BASE_PADDING_PX = 8
+const TREE_ROW_RIGHT_PADDING_PX = 8
+const TREE_CHEVRON_SLOT_PX = 16
+const TREE_ICON_SLOT_PX = 20
+const TREE_GAP_PX = 8
+const TREE_COUNT_EXTRA_PX = 32
+const TREE_WIDTH_SAFETY_PX = 32
+
+// ── Virtualized flat Objects list ───────────────────────────────────────────
+// The Objects folder can hold tens of thousands of entries, each of which may
+// expand into compositional children. Its visible forest is flattened into one
+// linear array and windowed, so only rows in (or near) the viewport are mounted
+// instead of rendering the whole catalog at once.
+
+export function VirtualObjectRows({
+  roots,
+  scrollRef,
+  contentRef,
+  filterText,
+}: {
+  roots: ObjectInstance[]
+  scrollRef: React.RefObject<HTMLDivElement>
+  contentRef: React.RefObject<HTMLDivElement>
+  filterText: string
+}) {
+  const expandedNodes = useExplorerStore(s => s.expandedNodes)
+  const childObjects = useExplorerStore(s => s.childObjects)
+  const compositionCache = useExplorerStore(s => s.compositionCache)
+
+  // Memoized so scroll-driven re-renders (which don't change any of these) reuse
+  // the flattened list instead of re-walking the whole forest each frame.
+  const rows = useMemo(
+    () => flattenObjectForest(roots, expandedNodes, childObjects, compositionCache, filterText),
+    [roots, expandedNodes, childObjects, compositionCache, filterText]
+  )
+
+  const listRef = useRef<HTMLDivElement>(null)
+  const [rowHeight, setRowHeight] = useState(ESTIMATED_ROW_HEIGHT)
+  const [scrollMargin, setScrollMargin] = useState(0)
+  const [listMinWidth, setListMinWidth] = useState(0)
+
+  // Offset of this list within the shared scroll container. It shifts whenever
+  // content above it (the Namespaces folder) grows or collapses, so recompute on
+  // any size change of the tree body. The +scrollTop term makes it independent
+  // of the current scroll position.
+  useLayoutEffect(() => {
+    const scrollEl = scrollRef.current
+    const contentEl = contentRef.current
+    const listEl = listRef.current
+    if (!scrollEl || !contentEl || !listEl) return
+    const measure = () => {
+      const margin =
+        listEl.getBoundingClientRect().top -
+        scrollEl.getBoundingClientRect().top +
+        scrollEl.scrollTop
+      setScrollMargin(prev => (Math.abs(prev - margin) > 0.5 ? margin : prev))
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(contentEl)
+    return () => ro.disconnect()
+  }, [scrollRef, contentRef])
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => rowHeight,
+    overscan: 12,
+    scrollMargin,
+    getItemKey: (index) => rows[index].key,
+  })
+
+  const virtualItems = virtualizer.getVirtualItems()
+  const paddingTop = virtualItems.length > 0 ? virtualItems[0].start - scrollMargin : 0
+  const paddingBottom =
+    virtualItems.length > 0
+      ? virtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1].end - scrollMargin)
+      : 0
+
+  // The outer tree uses max-content width for horizontal scrolling. Because the
+  // virtual list only mounts visible rows, compute a stable width from every
+  // flattened row so long offscreen labels can still extend the scrollbar.
+  useLayoutEffect(() => {
+    if (rows.length === 0) {
+      setListMinWidth(0)
+      return
+    }
+
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d')
+    const labelEl = listRef.current?.querySelector('.tree-node .whitespace-nowrap')
+    const styleSource = labelEl ?? listRef.current
+    if (context && styleSource) {
+      const style = window.getComputedStyle(styleSource)
+      context.font = style.font || `${style.fontSize} ${style.fontFamily}`
+    }
+    const measureText = (text: string) => context?.measureText(text).width ?? text.length * 8
+
+    let widest = 0
+    for (const row of rows) {
+      const leftPadding = row.depth * TREE_INDENT_PX + TREE_BASE_PADDING_PX
+      const label = row.kind === 'marker' ? row.message : getObjectLabel(row.obj)
+      let width = leftPadding + measureText(label) + TREE_ROW_RIGHT_PADDING_PX + TREE_WIDTH_SAFETY_PX
+      if (row.kind === 'object') {
+        width += TREE_CHEVRON_SLOT_PX + TREE_ICON_SLOT_PX + TREE_GAP_PX * 2
+        if (row.count !== undefined) {
+          width += TREE_COUNT_EXTRA_PX + measureText(String(row.count))
+        }
+      }
+      widest = Math.max(widest, Math.ceil(width))
+    }
+    setListMinWidth(prev => (Math.abs(prev - widest) > 0.5 ? widest : prev))
+  }, [rows])
+
+  // Resolve composition chevrons for the rows currently in view so they reflect
+  // real child counts instead of the optimistic default — without ever resolving
+  // the whole catalog at once. Debounced so it fires once scrolling settles.
+  useEffect(() => {
+    const client = getClient()
+    if (!client) return
+    const targets: ObjectInstance[] = []
+    for (const vi of virtualItems) {
+      const row = rows[vi.index]
+      if (row.kind === 'object' && row.obj.isComposition && !compositionCache.has(row.obj.elementId)) {
+        targets.push(row.obj)
+      }
+    }
+    if (targets.length === 0) return
+    const handle = setTimeout(() => { void resolveCompositionFlags(client, targets) }, 150)
+    return () => clearTimeout(handle)
+  }, [virtualItems, rows, compositionCache])
+
+  // Measure the true row height once from the first mounted object row so the
+  // spacer math matches the DOM regardless of platform/theme (emoji glyph
+  // heights differ across OSes).
+  const measuredRef = useRef(false)
+  const measureFirstRow = useCallback((el: HTMLDivElement | null) => {
+    if (!el || measuredRef.current) return
+    const h = el.getBoundingClientRect().height
+    if (h > 0) {
+      measuredRef.current = true
+      if (Math.abs(h - rowHeight) > 0.5) setRowHeight(h)
+    }
+  }, [rowHeight])
+
+  return (
+    <div ref={listRef} style={listMinWidth > 0 ? { minWidth: listMinWidth } : undefined}>
+      <div style={{ paddingTop, paddingBottom }}>
+        {virtualItems.map((vi, i) => {
+          const row = rows[vi.index]
+          const measure = i === 0 && row.kind === 'object' ? measureFirstRow : undefined
+          if (row.kind === 'marker') {
+            return (
+              <div
+                key={row.key}
+                style={{ paddingLeft: `${row.depth * 16 + 8}px`, height: rowHeight }}
+                className="flex items-center text-i3x-text-muted text-sm"
+              >
+                {row.message}
+              </div>
+            )
+          }
+          return (
+            <div key={row.key} ref={measure}>
+              <TreeNode
+                id={`obj:${row.obj.elementId}`}
+                label={getObjectLabel(row.obj)}
+                count={row.count}
+                type="object"
+                data={row.obj}
+                depth={row.depth}
+                hasChildren={row.hasChildren}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/tree/treeData.ts
+++ b/src/components/tree/treeData.ts
@@ -1,0 +1,163 @@
+import type { I3XClient } from '../../api/client'
+import { useExplorerStore } from '../../stores/explorer'
+import type { ObjectInstance } from '../../api/types'
+
+// Special folder IDs
+export const NAMESPACES_FOLDER_ID = 'folder:namespaces'
+export const OBJECTS_FOLDER_ID = 'folder:objects'
+export const HIERARCHICAL_FOLDER_ID = 'folder:hierarchical'
+
+// Max depth for tree rendering to prevent infinite loops
+export const MAX_TREE_DEPTH = 20
+
+// Fallback row height until the real one is measured from the first mounted row.
+export const ESTIMATED_ROW_HEIGHT = 28
+
+// Resolve chevron state for a set of compositional parents by asking the server
+// what /objects/related actually returns — i.e. the same data the render filter
+// sees at expansion time. Single batch round trip; only unresolved isComposition
+// objects are queried, so callers can pass a superset cheaply.
+export async function resolveCompositionFlags(client: I3XClient, loaded: ObjectInstance[]): Promise<void> {
+  if (loaded.length === 0) return
+  const { compositionCache, mergeCompositionFlags } = useExplorerStore.getState()
+  const toResolve: string[] = []
+  for (const obj of loaded) {
+    if (obj.isComposition && !compositionCache.has(obj.elementId)) {
+      toResolve.push(obj.elementId)
+    }
+  }
+  if (toResolve.length === 0) return
+  const additions = new Map<string, number>()
+  try {
+    const related = await client.getRelatedObjectsBatch(toResolve, 'HasComponent')
+    for (const parentId of toResolve) {
+      const children = related.get(parentId) ?? []
+      const qualifyingCount = children.filter(c =>
+        c.isComposition && c.elementId !== parentId && c.parentId === parentId
+      ).length
+      additions.set(parentId, qualifyingCount)
+    }
+  } catch (err) {
+    console.error('Failed to resolve composition flags via /objects/related:', err)
+  }
+  if (additions.size > 0) mergeCompositionFlags(additions)
+}
+
+// Coalesce + throttle full "all objects" refetches. Expanding a hierarchy node
+// refetches the entire object set to surface dynamically-discovered objects
+// (e.g. MQTT topics arriving over time). On large catalogs that full refetch is
+// expensive, so rapid navigation shares one in-flight request and skips
+// refetches that ran within a short window. Folder opens and the periodic
+// background poll pass force=true, so freshness is still guaranteed.
+//
+// Composition chevrons are resolved lazily for the visible window (see
+// VirtualObjectRows), never for the whole catalog here — a single batch over
+// tens of thousands of objects is slow and can fail, leaving chevrons wrong.
+const ALL_OBJECTS_REFETCH_TTL_MS = 3000
+let allObjectsFetchedAt = 0
+let allObjectsInFlight: Promise<void> | null = null
+
+export async function refreshAllObjects(client: I3XClient, force = false): Promise<void> {
+  if (allObjectsInFlight) return allObjectsInFlight
+  if (!force && Date.now() - allObjectsFetchedAt < ALL_OBJECTS_REFETCH_TTL_MS) return
+  allObjectsInFlight = (async () => {
+    try {
+      const objects = await client.getObjects()
+      useExplorerStore.getState().setAllObjects(objects)
+      allObjectsFetchedAt = Date.now()
+    } finally {
+      allObjectsInFlight = null
+    }
+  })()
+  return allObjectsInFlight
+}
+
+// Chevron predicate: consult the compositionCache, which holds the actual child
+// count resolved via batched /objects/related. If we haven't resolved this
+// object yet, fall back to its isComposition flag (chevron may show momentarily
+// until the resolver lands).
+export function hasCompositionChildren(obj: ObjectInstance, cache: Map<string, number>): boolean {
+  if (!obj.isComposition) return false
+  const cached = cache.get(obj.elementId)
+  return cached === undefined ? true : cached > 0
+}
+
+// Get display label for an object, handling special cases like root "/"
+export function getObjectLabel(obj: ObjectInstance): string {
+  if (obj.displayName && obj.displayName.trim()) {
+    return obj.displayName
+  }
+  // Fallback to elementId for objects with empty displayName (e.g., root "/")
+  return obj.elementId
+}
+
+// ── Flattened Objects forest ────────────────────────────────────────────────
+// The Objects folder can hold tens of thousands of entries, each of which may
+// expand into compositional children. Its visible forest is flattened into one
+// linear array so it can be windowed (see VirtualObjectRows).
+
+export interface FlatObjectRow {
+  kind: 'object'
+  key: string
+  obj: ObjectInstance
+  depth: number
+  hasChildren: boolean
+  count?: number
+}
+export interface FlatMarkerRow {
+  kind: 'marker'
+  key: string
+  depth: number
+  message: string
+}
+export type FlatRow = FlatObjectRow | FlatMarkerRow
+
+// Produce the ordered, visible rows of the Objects forest, mirroring the
+// expansion, filter, and cycle/depth guards that ObjectNode applies when it
+// renders recursively.
+export function flattenObjectForest(
+  roots: ObjectInstance[],
+  expandedNodes: Set<string>,
+  childObjects: Map<string, ObjectInstance[]>,
+  compositionCache: Map<string, number>,
+  filterText: string
+): FlatRow[] {
+  const rows: FlatRow[] = []
+  const walk = (obj: ObjectInstance, depth: number, ancestors: Set<string>, path: string) => {
+    const key = `${path}/${obj.elementId}`
+    if (depth > MAX_TREE_DEPTH || ancestors.has(obj.elementId)) {
+      rows.push({
+        kind: 'marker',
+        key: `${key}#stop`,
+        depth,
+        message: ancestors.has(obj.elementId) ? '(cycle detected)' : '(max depth reached)',
+      })
+      return
+    }
+    const children = childObjects.get(obj.elementId) ?? []
+    const cachedCount = compositionCache.get(obj.elementId)
+    const childCount = children.length > 0 ? children.length : cachedCount
+    rows.push({
+      kind: 'object',
+      key,
+      obj,
+      depth,
+      hasChildren: hasCompositionChildren(obj, compositionCache),
+      count: childCount && childCount > 0 ? childCount : undefined,
+    })
+    if (!expandedNodes.has(`obj:${obj.elementId}`)) return
+    const childAncestors = new Set(ancestors)
+    childAncestors.add(obj.elementId)
+    for (const child of children) {
+      if (
+        filterText &&
+        !child.displayName.toLowerCase().includes(filterText) &&
+        !child.elementId.toLowerCase().includes(filterText) &&
+        !child.namespaceUri.toLowerCase().includes(filterText)
+      ) continue
+      walk(child, depth + 1, childAncestors, key)
+    }
+  }
+  for (const obj of roots) walk(obj, 1, new Set<string>(), 'all')
+  return rows
+}

--- a/src/stores/explorer.ts
+++ b/src/stores/explorer.ts
@@ -31,6 +31,14 @@ interface ExplorerState {
   // via batched POST /objects/related so it never disagrees with the render
   // filter applied at expansion time. Also drives chevron state (count > 0).
   compositionCache: Map<string, number>
+  // elementId → its object type, rebuilt once whenever objectTypes changes.
+  // Shared by every tree node for icon bucketing so a node never has to build
+  // a Map over all object types on its own.
+  typeIndex: Map<string, ObjectType>
+  // parentId → its direct children, rebuilt once whenever allObjects changes.
+  // The hierarchy view looks up children here in O(1) instead of scanning the
+  // entire allObjects array (O(n)) on every node.
+  childrenByParent: Map<string, ObjectInstance[]>
   expandedNodes: Set<string>
   selectedItem: SelectedItem | null
   isLoading: boolean
@@ -66,6 +74,8 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
   hierarchicalRoots: [],
   childObjects: new Map(),
   compositionCache: new Map(),
+  typeIndex: new Map(),
+  childrenByParent: new Map(),
   expandedNodes: new Set(),
   selectedItem: null,
   isLoading: false,
@@ -75,7 +85,10 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
   sidebarCollapsed: false,
 
   setNamespaces: (namespaces) => set({ namespaces }),
-  setObjectTypes: (types) => set({ objectTypes: types }),
+  setObjectTypes: (types) => set({
+    objectTypes: types,
+    typeIndex: new Map(types.map(t => [t.elementId, t])),
+  }),
 
   setObjects: (typeId, objects) => {
     const current = get().objects
@@ -84,7 +97,20 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
     set({ objects: updated })
   },
 
-  setAllObjects: (objects) => set({ allObjects: objects }),
+  setAllObjects: (objects) => {
+    // Index children by parentId once here so the hierarchy view can resolve a
+    // node's children with a single Map lookup instead of filtering the whole
+    // list per node.
+    const childrenByParent = new Map<string, ObjectInstance[]>()
+    for (const o of objects) {
+      const pid = o.parentId
+      if (!pid) continue
+      const arr = childrenByParent.get(pid)
+      if (arr) arr.push(o)
+      else childrenByParent.set(pid, [o])
+    }
+    set({ allObjects: objects, childrenByParent })
+  },
   setHierarchicalRoots: (roots) => set({ hierarchicalRoots: roots }),
 
   setChildObjects: (parentId, children) => {
@@ -141,6 +167,8 @@ export const useExplorerStore = create<ExplorerState>((set, get) => ({
     hierarchicalRoots: [],
     childObjects: new Map(),
     compositionCache: new Map(),
+    typeIndex: new Map(),
+    childrenByParent: new Map(),
     expandedNodes: new Set(),
     selectedItem: null,
     isLoading: false,


### PR DESCRIPTION
## Summary

Improves tree rendering performance for large i3X catalogs by virtualizing the flat Objects view and reducing repeated work during tree refresh, filtering, and hierarchy rendering.

This change keeps the existing browsing behavior intact while making catalogs with tens of thousands of objects much more responsive.

## What Changed

- Added `@tanstack/react-virtual` and introduced a virtualized flat Objects list.
- Split tree rendering into focused modules:
  - `TreeNode`
  - `VirtualObjectRows`
  - `treeData`
- Added store-level indexes for frequently reused lookup data:
  - `typeIndex` for object type icon bucketing.
  - `childrenByParent` for O(1) hierarchy child lookup.
- Coalesced and throttled full-catalog refreshes triggered by hierarchy expansion.
- Deferred composition-chevron resolution to visible virtual rows instead of resolving the entire catalog at once.
- Preserved horizontal scrolling for long/deep object labels by computing a stable virtual-list width from the full flattened row set.
- Updated project documentation to describe the new rendering and refresh behavior.

## Why

Large catalogs can contain tens of thousands of objects. Rendering every object row in the flat Objects folder, scanning the full object list for each hierarchy node, and resolving all composition flags eagerly created avoidable UI cost.

The new approach keeps only visible flat-object rows mounted, reuses precomputed indexes, and limits expensive server calls while preserving freshness where users expect it.

## Validation

- `npm run typecheck`
- `npm run build:web`

`npm run lint` was not run because the repository currently does not include an ESLint configuration file, so the existing lint script fails before checking source files.

## Notes

This PR is intentionally scoped to rendering and tree-browsing performance. It does not change the i3X API client contract or server wire-format handling.